### PR TITLE
feat: adjust to message bubble boxes - joule like, add thinking mode, remove context from input

### DIFF
--- a/gui/src/components/StepContainer/StepContainer.tsx
+++ b/gui/src/components/StepContainer/StepContainer.tsx
@@ -102,6 +102,7 @@ export default function StepContainer(props: StepContainerProps) {
                   isRenderingInStepContainer
                   source={stripImages(props.item.message.content)}
                   itemIndex={props.index}
+                  isAssistantMessage={true} // BAS Customization: Enable assistant messages styles
                 />
               </>
             )}

--- a/gui/src/components/StepContainer/StepContainer.tsx
+++ b/gui/src/components/StepContainer/StepContainer.tsx
@@ -3,7 +3,7 @@ import { renderChatMessage, stripImages } from "core/util/messageContent";
 import { useEffect, useState } from "react";
 import { useDispatch } from "react-redux";
 import styled from "styled-components";
-import { vscBackground } from "..";
+import { vscBackground, ChatBubbleContainer, AssistantMessageBubble } from "..";
 import { useAppSelector } from "../../redux/hooks";
 import { selectUIConfig } from "../../redux/slices/configSlice";
 import { deleteMessage } from "../../redux/slices/sessionSlice";
@@ -19,15 +19,17 @@ interface StepContainerProps {
   isLast: boolean;
 }
 
+//BAS Customization - Remove background color since chat bubble handles it
 const ContentDiv = styled.div<{ fontSize?: number }>`
   padding: 4px;
   padding-left: 6px;
   padding-right: 6px;
 
-  background-color: ${vscBackground};
+  background-color: transparent;
   font-size: ${getFontSize()}px;
   overflow: hidden;
 `;
+//BAS Customization End
 
 export default function StepContainer(props: StepContainerProps) {
   const dispatch = useDispatch();
@@ -79,43 +81,49 @@ export default function StepContainer(props: StepContainerProps) {
     );
   }
 
+  //BAS Customization - WhatsApp-style: Only message content in gray bubble, actions outside
   return (
-    <div>
-      <ContentDiv>
-        {uiConfig?.displayRawMarkdown ? (
-          <pre
-            className="max-w-full overflow-x-auto whitespace-pre-wrap break-words p-4"
-            style={{ fontSize: getFontSize() - 2 }}
-          >
-            {renderChatMessage(props.item.message)}
-          </pre>
-        ) : (
-          <>
-            <Reasoning {...props} />
+    <ChatBubbleContainer isUser={false}>
+      <div style={{ display: "flex", flexDirection: "column", alignItems: "flex-start", width: "100%" }}>
+        <AssistantMessageBubble>
+          <ContentDiv>
+            {uiConfig?.displayRawMarkdown ? (
+              <pre
+                className="max-w-full overflow-x-auto whitespace-pre-wrap break-words p-4"
+                style={{ fontSize: getFontSize() - 2 }}
+              >
+                {renderChatMessage(props.item.message)}
+              </pre>
+            ) : (
+              <>
+                <Reasoning {...props} />
 
-            <StyledMarkdownPreview
-              isRenderingInStepContainer
-              source={stripImages(props.item.message.content)}
-              itemIndex={props.index}
-            />
-          </>
+                <StyledMarkdownPreview
+                  isRenderingInStepContainer
+                  source={stripImages(props.item.message.content)}
+                  itemIndex={props.index}
+                />
+              </>
+            )}
+            {props.isLast && <ThinkingIndicator historyItem={props.item} />}
+          </ContentDiv>
+        </AssistantMessageBubble>
+        {/* We want to occupy space in the DOM regardless of whether the actions are visible to avoid jank on stream complete */}
+        {!hideActionSpace && (
+          <div className={`mt-2 h-7 transition-opacity duration-300 ease-in-out`}>
+            {!hideActions && (
+              <ResponseActions
+                isTruncated={isTruncated}
+                onDelete={onDelete}
+                onContinueGeneration={onContinueGeneration}
+                index={props.index}
+                item={props.item}
+              />
+            )}
+          </div>
         )}
-        {props.isLast && <ThinkingIndicator historyItem={props.item} />}
-      </ContentDiv>
-      {/* We want to occupy space in the DOM regardless of whether the actions are visible to avoid jank on stream complete */}
-      {!hideActionSpace && (
-        <div className={`mt-2 h-7 transition-opacity duration-300 ease-in-out`}>
-          {!hideActions && (
-            <ResponseActions
-              isTruncated={isTruncated}
-              onDelete={onDelete}
-              onContinueGeneration={onContinueGeneration}
-              index={props.index}
-              item={props.item}
-            />
-          )}
-        </div>
-      )}
-    </div>
+      </div>
+    </ChatBubbleContainer>
   );
+  //BAS Customization End
 }

--- a/gui/src/components/StyledMarkdownPreview/index.tsx
+++ b/gui/src/components/StyledMarkdownPreview/index.tsx
@@ -11,6 +11,7 @@ import {
   vscBackground,
   vscEditorBackground,
   vscForeground,
+  assistantMessageTextColor, // BAS Customization: Import assistant message text color
 } from "..";
 import useUpdatingRef from "../../hooks/useUpdatingRef";
 import { useAppSelector } from "../../redux/hooks";
@@ -34,6 +35,7 @@ const StyledMarkdown = styled.div<{
   fontSize?: number;
   whiteSpace: string;
   bgColor: string;
+  isAssistantMessage?: boolean; // BAS Customization: Add prop for conditional styles
 }>`
   h1 {
     font-size: 1.25em;
@@ -104,7 +106,7 @@ const StyledMarkdown = styled.div<{
   font-size: ${(props) => props.fontSize || getFontSize()}px;
   padding-left: 8px;
   padding-right: 8px;
-  color: ${vscForeground};
+  color: ${(props) => props.isAssistantMessage ? assistantMessageTextColor : vscForeground}; // BAS Customization: Use assistantMessageTextColor for assistant messages
 
   p,
   li,
@@ -114,9 +116,8 @@ const StyledMarkdown = styled.div<{
   }
 
   > *:last-child {
-    margin-bottom: 0;
-    // BAS Customization - Remove top margin for last child
-    margin-top: 0;
+  // BAS Customization - Remove bottom margin for last child  
+  // margin-bottom: 0;
   }
 `;
 
@@ -130,6 +131,7 @@ interface StyledMarkdownPreviewProps {
   disableManualApply?: boolean;
   forceStreamId?: string;
   expandCodeblocks?: boolean;
+  isAssistantMessage?: boolean; // BAS Customization: Set specific styles for assistant messages
 }
 
 const HLJS_LANGUAGE_CLASSNAME_PREFIX = "language-";
@@ -361,6 +363,7 @@ const StyledMarkdownPreview = memo(function StyledMarkdownPreview(
       whiteSpace={codeWrapState}
       // BAS Customization - Use parent background color if specified
       bgColor=""
+      isAssistantMessage={props.isAssistantMessage} // BAS Customization: Pass prop for conditional text color
     >
       {reactContent}
     </StyledMarkdown>

--- a/gui/src/components/StyledMarkdownPreview/index.tsx
+++ b/gui/src/components/StyledMarkdownPreview/index.tsx
@@ -115,6 +115,8 @@ const StyledMarkdown = styled.div<{
 
   > *:last-child {
     margin-bottom: 0;
+    // BAS Customization - Remove top margin for last child
+    margin-top: 0;
   }
 `;
 
@@ -357,7 +359,8 @@ const StyledMarkdownPreview = memo(function StyledMarkdownPreview(
       contentEditable="false"
       fontSize={getFontSize()}
       whiteSpace={codeWrapState}
-      bgColor={props.useParentBackgroundColor ? "" : vscBackground}
+      // BAS Customization - Use parent background color if specified
+      bgColor=""
     >
       {reactContent}
     </StyledMarkdown>

--- a/gui/src/components/ThinkingDots.bas.tsx
+++ b/gui/src/components/ThinkingDots.bas.tsx
@@ -1,0 +1,37 @@
+// BAS Customization - Animated three purple dots for "thinking" state
+import React from "react";
+import styled, { keyframes } from "styled-components";
+import { userMessageBubbleColor } from ".";
+
+const bounce = keyframes`
+  0%, 80%, 100% { transform: scale(1); opacity: 0.5; }
+  40% { transform: scale(1.3); opacity: 1; }
+`;
+
+const DotsWrapper = styled.div`
+  display: flex;
+  align-items center;
+  justify-content: flex-start;
+  height: 32px;
+  padding: 0 8px;
+`;
+
+const Dot = styled.div<{ delay: string }>`
+  width: 10px;
+  height: 10px;
+  margin: 0 4px;
+  border-radius: 50%;
+  background: ${userMessageBubbleColor};
+  animation: ${bounce} 1.2s infinite;
+  animation-delay: ${({ delay }) => delay};
+`;
+
+export const ThinkingDots: React.FC = () => (
+  <DotsWrapper>
+    <Dot delay="0s" />
+    <Dot delay="0.2s" />
+    <Dot delay="0.4s" />
+  </DotsWrapper>
+);
+
+// BAS Customization End

--- a/gui/src/components/index.ts
+++ b/gui/src/components/index.ts
@@ -8,8 +8,8 @@ export const greenButtonColor = "#189e72";
 /* BAS Customization - WhatsApp-style chat bubble colors */
 export const userMessageBubbleColor = "#E5D8FA"; // Light purple for user messages
 export const assistantMessageBubbleColor = "#F3F4F6"; // Light gray for assistant messages
-export const userMessageTextColor = "#3B2170"; // Darker purple text for contrast
-export const assistantMessageTextColor = "#1F2937"; // Dark text on light gray
+export const userMessageTextColor = "#1D2D3E "; 
+export const assistantMessageTextColor = "#1D2D3E "; 
 /* BAS Customization End */
 
 export const vscInputBackground = varWithFallback("input-background");
@@ -275,19 +275,25 @@ export const ChatBubble = styled.div<{ isUser: boolean }>`
   `}
 `;
 
+/* BAS Customization: User bubble 8px radius except right bottom */
 export const UserMessageBubble = styled(ChatBubble).attrs({ isUser: true })`
   display: inline-block;
   text-align: left;
   padding: 0px;
-  border-radius: 10px;
+  border-radius: 8px 8px 0px 8px;
   min-width: unset;
   max-width: 80%;
   line-height: 1.4;
 `;
 
+/* BAS Customization: Assistant bubble 8px radius except left bottom 0px */
 export const AssistantMessageBubble = styled(ChatBubble).attrs({ isUser: false })`
-  /* BAS Customization - tighter fit for assistant bubble */
   display: inline-block;
   text-align: left;
+  padding-left: 10px;
+  padding-right:10px;
+  padding-top: 0px;
+  padding-bottom: 0px;
+  border-radius: 8px 8px 8px 0px;
 `;
 /* BAS Customization End */

--- a/gui/src/components/index.ts
+++ b/gui/src/components/index.ts
@@ -5,6 +5,13 @@ export const defaultBorderRadius = "5px";
 export const lightGray = "#999998";
 export const greenButtonColor = "#189e72";
 
+/* BAS Customization - WhatsApp-style chat bubble colors */
+export const userMessageBubbleColor = "#E5D8FA"; // Light purple for user messages
+export const assistantMessageBubbleColor = "#F3F4F6"; // Light gray for assistant messages
+export const userMessageTextColor = "#3B2170"; // Darker purple text for contrast
+export const assistantMessageTextColor = "#1F2937"; // Dark text on light gray
+/* BAS Customization End */
+
 export const vscInputBackground = varWithFallback("input-background");
 export const vscQuickInputBackground = varWithFallback("input-background");
 export const vscBackground = varWithFallback("background");
@@ -232,3 +239,55 @@ export const AnimatedEllipsis = styled.span`
     }
   }
 `;
+
+//BAS Customization - Chat bubble components
+/* BAS Customization - Increase vertical gap between bubbles */
+export const ChatBubbleContainer = styled.div<{ isUser: boolean }>`
+  display: flex;
+  width: 100%;
+  margin: 0 0 20px 0;
+  justify-content: ${({ isUser }) => (isUser ? "flex-end" : "flex-start")};
+`;
+
+export const ChatBubble = styled.div<{ isUser: boolean }>`
+  max-width: 70%;
+  min-width: 60px;
+  padding: 8px 16px;
+  border-radius: 12px;
+  background-color: ${({ isUser }) =>
+    isUser ? userMessageBubbleColor : assistantMessageBubbleColor};
+  color: ${({ isUser }) =>
+    isUser ? userMessageTextColor : assistantMessageTextColor};
+  word-wrap: break-word;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.06);
+
+  ${({ isUser }) =>
+    isUser
+      ? `
+    border-bottom-right-radius: 6px;
+    margin-right: 12px;
+    align-self: flex-end;
+  `
+      : `
+    border-bottom-left-radius: 6px;
+    margin-left: 12px;
+    align-self: flex-start;
+  `}
+`;
+
+export const UserMessageBubble = styled(ChatBubble).attrs({ isUser: true })`
+  display: inline-block;
+  text-align: left;
+  padding: 0px;
+  border-radius: 10px;
+  min-width: unset;
+  max-width: 80%;
+  line-height: 1.4;
+`;
+
+export const AssistantMessageBubble = styled(ChatBubble).attrs({ isUser: false })`
+  /* BAS Customization - tighter fit for assistant bubble */
+  display: inline-block;
+  text-align: left;
+`;
+/* BAS Customization End */

--- a/gui/src/components/mainInput/ContinueInputBox.tsx
+++ b/gui/src/components/mainInput/ContinueInputBox.tsx
@@ -2,7 +2,7 @@ import { Editor, JSONContent } from "@tiptap/react";
 import { ContextItemWithId, InputModifiers, RuleWithSource } from "core";
 import { useMemo } from "react";
 import styled, { keyframes } from "styled-components";
-import { defaultBorderRadius, vscBackground } from "..";
+import { defaultBorderRadius, vscBackground, ChatBubbleContainer, UserMessageBubble } from "..";
 import { useAppSelector } from "../../redux/hooks";
 import { selectSlashCommandComboBoxInputs } from "../../redux/selectors";
 import { ContextItemsPeek } from "./belowMainInput/ContextItemsPeek";
@@ -118,6 +118,45 @@ function ContinueInputBox(props: ContinueInputBoxProps) {
     : {};
 
   const { appliedRules = [], contextItems = [] } = props;
+
+  //BAS Customization - Wrap historical user messages in chat bubbles
+  if (!props.isMainInput) {
+    return (
+      <div
+        className={`${props.hidden ? "hidden" : ""}`}
+        data-testid="continue-input-box"
+      >
+        <ChatBubbleContainer isUser={true}>
+          <UserMessageBubble>
+            <div className={`relative flex flex-col`}>
+              <TipTapEditor
+                editorState={props.editorState}
+                onEnter={props.onEnter}
+                placeholder={placeholder}
+                isMainInput={props.isMainInput ?? false}
+                availableContextProviders={filteredContextProviders}
+                availableSlashCommands={filteredSlashCommands}
+                historyKey={historyKey}
+                toolbarOptions={toolbarOptions}
+                inputId={props.inputId}
+                isInChatBubble={true}
+              />
+            </div>
+            {(appliedRules.length > 0 || contextItems.length > 0) && (
+              <div className="mt-2 flex flex-col">
+                <RulesPeek appliedRules={props.appliedRules} />
+                <ContextItemsPeek
+                  contextItems={props.contextItems}
+                  isCurrentContextPeek={props.isLastUserInput}
+                />
+              </div>
+            )}
+          </UserMessageBubble>
+        </ChatBubbleContainer>
+      </div>
+    );
+  }
+  //BAS Customization End
 
   return (
     <div

--- a/gui/src/components/mainInput/InputToolbar.tsx
+++ b/gui/src/components/mainInput/InputToolbar.tsx
@@ -135,18 +135,8 @@ function InputToolbar(props: InputToolbarProps) {
                   </HoverItem>
                 </>
               ))}
-            {props.toolbarOptions?.hideAddContext || (
-              <HoverItem onClick={props.onAddContextItem}>
-                <AtSymbolIcon
-                  data-tooltip-id="add-context-item-tooltip"
-                  className="h-3 w-3 hover:brightness-125"
-                />
-
-                <ToolTip id="add-context-item-tooltip" place="top">
-                  Attach Context
-                </ToolTip>
-              </HoverItem>
-            )}
+            {/* BAS Customization: Hide the "@" context button */}
+            {/* BAS Customization End */}
           </div>
         </div>
 
@@ -156,35 +146,8 @@ function InputToolbar(props: InputToolbarProps) {
             fontSize: tinyFont,
           }}
         >
-          {!props.toolbarOptions?.hideUseCodebase && !isInEdit && (
-            <div
-              className={`${toolsSupported ? "md:flex" : "int:flex"} hover:underline" hidden transition-colors duration-200`}
-            >
-              {props.activeKey === "Alt" ? (
-                <HoverItem className="underline">
-                  {`${getAltKeyLabel()}⏎
-                  ${useActiveFile ? "No active file" : "Active file"}`}
-                </HoverItem>
-              ) : (
-                <HoverItem
-                  className={props.activeKey === "Meta" ? "underline" : ""}
-                  onClick={(e) =>
-                    props.onEnter?.({
-                      useCodebase: true,
-                      noContext: !useActiveFile,
-                    })
-                  }
-                >
-                  <span data-tooltip-id="add-codebase-context-tooltip">
-                    {getMetaKeyLabel()}⏎ @codebase
-                  </span>
-                  <ToolTip id="add-codebase-context-tooltip" place="top-end">
-                    Send With Codebase as Context ({getMetaKeyLabel()}⏎)
-                  </ToolTip>
-                </HoverItem>
-              )}
-            </div>
-          )}
+          {/* BAS Customization: Hide the codebase context button */}
+          {/* BAS Customization End */}
 
           {isInEdit && (
             <HoverItem

--- a/gui/src/components/mainInput/Lump/LumpToolbar/GeneratingIndicator.tsx
+++ b/gui/src/components/mainInput/Lump/LumpToolbar/GeneratingIndicator.tsx
@@ -1,14 +1,7 @@
 import { AnimatedEllipsis } from "../../..";
 
-export function GeneratingIndicator({
-  text = "Generating",
-}: {
-  text?: string;
-}) {
-  return (
-    <div className="text-description-muted text-xs">
-      <span>{text}</span>
-      <AnimatedEllipsis />
-    </div>
-  );
+/* BAS Customization: Hide GeneratingIndicator component */
+export function GeneratingIndicator() {
+  return null;
 }
+/* BAS Customization End */

--- a/gui/src/components/mainInput/Lump/LumpToolbar/IsApplyingToolbar.tsx
+++ b/gui/src/components/mainInput/Lump/LumpToolbar/IsApplyingToolbar.tsx
@@ -11,7 +11,11 @@ export const IsApplyingToolbar = () => {
 
   return (
     <Container>
-      <GeneratingIndicator text="Applying" />
+      {/* BAS Customization: Hide GeneratingIndicator component */}
+      {/* <GeneratingIndicator text="Applying" /> */}
+      {/* BAS Customization End */}
+      {/* BAS Customization: Show animated dots for "thinking" message */}
+      {/* This is handled in ThinkingBlockPeek, so we don't need to show it here */}
       <StopButton
         className="text-description"
         onClick={() => {

--- a/gui/src/components/mainInput/TipTapEditor/TipTapEditor.tsx
+++ b/gui/src/components/mainInput/TipTapEditor/TipTapEditor.tsx
@@ -232,7 +232,8 @@ export function TipTapEditor(props: TipTapEditorProps) {
         event.preventDefault();
       }}
     >
-      <div className="px-2.5 pb-1 pt-2">
+      {/* BAS Customization - Adjust padding left-right for user message box*/}
+      <div className="px-4 pb-1 pt-2"> 
         <EditorContent
           className={`scroll-container overflow-y-scroll ${props.isMainInput ? "max-h-[70vh]" : ""}`}
           spellCheck={false}

--- a/gui/src/components/mainInput/TipTapEditor/TipTapEditor.tsx
+++ b/gui/src/components/mainInput/TipTapEditor/TipTapEditor.tsx
@@ -33,6 +33,10 @@ export interface TipTapEditorProps {
   // TODO: This isn't actually used anywhere in this component, but it appears
   // to be pulled into some of our TipTap extensions.
   inputId: string;
+  
+  //BAS Customization - Add prop to indicate if editor is in chat bubble
+  isInChatBubble?: boolean;
+  //BAS Customization End
 }
 
 export const TIPPY_DIV_ID = "tippy-js-div";
@@ -174,6 +178,7 @@ export function TipTapEditor(props: TipTapEditorProps) {
 
   return (
     <InputBoxDiv
+      isInChatBubble={props.isInChatBubble}
       onFocus={handleFocus}
       onBlur={handleBlur}
       onKeyDown={handleKeyDown}

--- a/gui/src/components/mainInput/TipTapEditor/components/StyledComponents.ts
+++ b/gui/src/components/mainInput/TipTapEditor/components/StyledComponents.ts
@@ -8,10 +8,12 @@ import {
   vscForeground,
   vscInputBackground,
   vscInputBorderFocus,
+  userMessageTextColor,
 } from "../../..";
 import { getFontSize } from "../../../../util";
 
-export const InputBoxDiv = styled.div<{}>`
+//BAS Customization - Updated InputBoxDiv to support chat bubbles
+export const InputBoxDiv = styled.div<{ isInChatBubble?: boolean }>`
   resize: none;
   font-family: inherit;
   border-radius: ${defaultBorderRadius};
@@ -19,13 +21,17 @@ export const InputBoxDiv = styled.div<{}>`
   margin: 0;
   height: auto;
   width: 100%;
-  background-color: ${vscInputBackground};
-  color: ${vscForeground};
+  background-color: ${({ isInChatBubble }) => 
+    isInChatBubble ? 'transparent' : vscInputBackground};
+  color: ${({ isInChatBubble }) => 
+    isInChatBubble ? userMessageTextColor : vscForeground};
 
-  border: 1px solid ${vscCommandCenterInactiveBorder};
+  border: ${({ isInChatBubble }) => 
+    isInChatBubble ? 'none' : `1px solid ${vscCommandCenterInactiveBorder}`};
   transition: border-color 0.15s ease-in-out;
   &:focus-within {
-    border: 1px solid ${vscCommandCenterActiveBorder};
+    border: ${({ isInChatBubble }) => 
+      isInChatBubble ? 'none' : `1px solid ${vscCommandCenterActiveBorder}`};
   }
 
   outline: none;
@@ -33,8 +39,8 @@ export const InputBoxDiv = styled.div<{}>`
 
   &:focus {
     outline: none;
-
-    border: 0.5px solid ${vscInputBorderFocus};
+    border: ${({ isInChatBubble }) => 
+      isInChatBubble ? 'none' : `0.5px solid ${vscInputBorderFocus}`};
   }
 
   &::placeholder {
@@ -44,6 +50,7 @@ export const InputBoxDiv = styled.div<{}>`
   display: flex;
   flex-direction: column;
 `;
+//BAS Customization End
 
 export const HoverDiv = styled.div`
   position: absolute;

--- a/gui/src/components/mainInput/belowMainInput/ThinkingBlockPeek.tsx
+++ b/gui/src/components/mainInput/belowMainInput/ThinkingBlockPeek.tsx
@@ -1,76 +1,12 @@
 // src/components/ThinkingBlockPeek.tsx
-import { ChevronDownIcon } from "@heroicons/react/24/outline";
-import { ChevronUpIcon } from "@heroicons/react/24/solid";
 import { ChatHistoryItem } from "core";
 import { useEffect, useState } from "react";
 import styled from "styled-components";
-import { defaultBorderRadius, lightGray, vscBackground } from "../..";
-import { getFontSize } from "../../../util";
-import StyledMarkdownPreview from "../../StyledMarkdownPreview";
+import { vscBackground } from "../..";
+import { ThinkingDots } from "../../ThinkingDots.bas";
+// BAS Customization: Remove old imports for spoiler/thinking text, add ThinkingDots
 
-const SpoilerButton = styled.div`
-  background-color: ${vscBackground};
-  width: fit-content;
-  margin: 8px 6px 0px 2px;
-  font-size: ${getFontSize() - 2}px;
-  border: 0.5px solid ${lightGray};
-  border-radius: ${defaultBorderRadius};
-  padding: 4px 8px;
-  color: ${lightGray};
-  cursor: pointer;
-  box-shadow:
-    0 4px 6px rgba(0, 0, 0, 0.1),
-    0 1px 3px rgba(0, 0, 0, 0.08);
-  transition: box-shadow 0.3s ease;
-
-  &:hover {
-    box-shadow:
-      0 6px 8px rgba(0, 0, 0, 0.15),
-      0 3px 6px rgba(0, 0, 0, 0.1);
-  }
-`;
-
-const ButtonContent = styled.div`
-  display: flex;
-  align-items: center;
-  gap: 6px;
-`;
-
-export const ThinkingText = styled.span`
-  position: relative;
-  padding-right: 12px;
-
-  &:after {
-    content: "...";
-    position: absolute;
-    animation: ellipsis 1s steps(4, end) infinite;
-    width: 0px;
-    display: inline-block;
-    overflow: hidden;
-  }
-
-  @keyframes ellipsis {
-    0%,
-    100% {
-      width: 0px;
-    }
-    33% {
-      width: 8px;
-    }
-    66% {
-      width: 16px;
-    }
-    90% {
-      width: 24px;
-    }
-  }
-`;
-
-const MarkdownWrapper = styled.div`
-  & > div > *:first-child {
-    margin-top: 0 !important;
-  }
-`;
+/* BAS Customization: Remove old thinking/markdown/spoiler styles for new thinking dots */
 
 interface ThinkingBlockPeekProps {
   content: string;
@@ -83,95 +19,26 @@ interface ThinkingBlockPeekProps {
 }
 
 function ThinkingBlockPeek({
-  content,
-  redactedThinking,
-  index,
-  prevItem,
   inProgress,
-  signature,
-  tokens,
-}: ThinkingBlockPeekProps) {
-  const [open, setOpen] = useState(false);
-  const [startTime, setStartTime] = useState<number | null>(null);
-  const [elapsedTime, setElapsedTime] = useState<string>("");
-
-  const duplicateRedactedThinkingBlock =
-    prevItem &&
-    prevItem.message.role === "thinking" &&
-    redactedThinking &&
-    prevItem.message.redactedThinking;
-
-  useEffect(() => {
-    if (inProgress) {
-      setStartTime(Date.now());
-      setElapsedTime("");
-    } else if (startTime) {
-      const endTime = Date.now();
-      const diff = endTime - startTime;
-      const diffString = `${(diff / 1000).toFixed(1)}s`;
-      setElapsedTime(diffString);
-    }
-  }, [inProgress]);
-
-  return duplicateRedactedThinkingBlock ? null : (
-    <div className="thread-message">
-      <div className="" style={{ backgroundColor: vscBackground }}>
-        <div
-          className="flex items-center justify-start pl-2 text-xs text-gray-300"
-          data-testid="thinking-block-peek"
-        >
-          <SpoilerButton onClick={() => setOpen((prev) => !prev)}>
-            <ButtonContent>
-              {inProgress ? (
-                <ThinkingText>
-                  {redactedThinking ? "Redacted Thinking" : "Thinking"}
-                </ThinkingText>
-              ) : redactedThinking ? (
-                "Redacted Thinking"
-              ) : (
-                "Thought" +
-                (elapsedTime ? ` for ${elapsedTime}` : "") +
-                (tokens ? ` (${tokens} tokens)` : "")
-              )}
-              {open ? (
-                <ChevronUpIcon className="h-3 w-3" />
-              ) : (
-                <ChevronDownIcon className="h-3 w-3" />
-              )}
-            </ButtonContent>
-          </SpoilerButton>
-        </div>
-
-        <div
-          className={`ml-2 mt-2 overflow-y-auto transition-none duration-300 ease-in-out ${
-            open ? "mb-2 mt-5 opacity-100" : "max-h-0 border-0 opacity-0"
-          }`}
-          style={{
-            borderLeft:
-              open && !redactedThinking
-                ? "2px solid var(--vscode-input-border, #606060)"
-                : "none",
-          }}
-        >
-          {redactedThinking ? (
-            <div className="pl-4 text-xs text-gray-400">
-              Thinking content redacted due to safety reasons.
-            </div>
-          ) : (
-            <>
-              <MarkdownWrapper className="-mt-1 px-0 pl-1">
-                <StyledMarkdownPreview
-                  isRenderingInStepContainer
-                  source={content}
-                  itemIndex={index}
-                />
-              </MarkdownWrapper>
-            </>
-          )}
-        </div>
+  item,
+}: ThinkingBlockPeekProps & { item?: any }) {
+  // BAS Customization: Show animated dots for "thinking" message
+  if (item && item.message.role === "thinking") {
+    return (
+      <div className="thread-message" style={{ marginLeft: 8 }}>
+        <ThinkingDots />
       </div>
-    </div>
-  );
+    );
+  }
+  // fallback for inProgress (legacy)
+  if (inProgress) {
+    return (
+      <div className="-message" style={{ marginLeft: 8 }}>
+        <ThinkingDots />
+      </div>
+    );
+  }
+  return null;
 }
 
 export default ThinkingBlockPeek;

--- a/gui/src/pages/gui/ToolCallDiv/index.tsx
+++ b/gui/src/pages/gui/ToolCallDiv/index.tsx
@@ -66,7 +66,18 @@ function getStatusIcon(state: ToolStatus) {
   }
 }
 
+//BAS Customization: Hide tool calling UI when BAS mode is enabled
+const IS_BAS = true;
+// END BAS Customization
+
 export function ToolCallDiv(props: ToolCallDivProps) {
+  
+  //BAS Customization: Hide tool calling UI when BAS mode is enabled
+  if (IS_BAS) {
+    return null;
+  }
+  //BAS Customization: Hide tool calling UI when BAS mode is enabled
+
   const availableTools = useAppSelector((state) => state.config.config.tools);
   const tool = useMemo(() => {
     return availableTools.find(

--- a/gui/src/redux/slices/sessionSlice.ts
+++ b/gui/src/redux/slices/sessionSlice.ts
@@ -145,6 +145,7 @@ export const sessionSlice = createSlice({
         state.history[index].contextItems = contextItems;
       }
     },
+    // BAS Customization: Insert a "thinking" message instead of an empty assistant message
     submitEditorAndInitAtIndex: (
       state,
       {
@@ -172,8 +173,8 @@ export const sessionSlice = createSlice({
         state.history = state.history.slice(0, index + 1).concat({
           message: {
             id: uuidv4(),
-            role: "assistant",
-            content: "", // IMPORTANT - this is subsequently updated by response streaming
+            role: "thinking",
+            content: "", // This will trigger the thinking dots in the chat
           },
           contextItems: [],
         });
@@ -192,8 +193,8 @@ export const sessionSlice = createSlice({
           {
             message: {
               id: uuidv4(),
-              role: "assistant",
-              content: "", // IMPORTANT - this is subsequently updated by response streaming
+              role: "thinking",
+              content: "", // This will trigger the thinking dots in the chat
             },
             contextItems: [],
           },
@@ -202,6 +203,7 @@ export const sessionSlice = createSlice({
 
       state.isStreaming = true;
     },
+    // BAS Customization End
     deleteMessage: (state, action: PayloadAction<number>) => {
       // Deletes the current assistant message and the previous user message
       state.history.splice(action.payload - 1, 2);


### PR DESCRIPTION
…t, adjust thinking mode

## Description

Added the following customizations to continue chat gui:
1. Wrap user and assistant messages with boxes/bubbles (to be similar to Joule UI) - with given text colors, paddings etc.
2. Add thinking mode inline the chat instead of the "generating" on top of continue input box
3. Remove "codebase" and "@" from the chat input field
4. Allow disabling tool calling from chat UI

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screenshots

Thinking mode:
<img width="841" height="769" alt="image" src="https://github.com/user-attachments/assets/2da870e9-bc4e-473b-b9a2-3a82da5a20d9" />

Chat boxes:
<img width="841" height="769" alt="image" src="https://github.com/user-attachments/assets/f377ca7d-e218-4e9f-bbab-c84898a22356" />


## Tests

[ What tests were added or updated to ensure the changes work as expected? ]
